### PR TITLE
[feat] Add X-Remote-User header

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -21,4 +21,4 @@ windows:
   - database:
       root: ./
       panes:
-        - pgcli postgres://taskcafe:taskcafe_test@localhost:8855/taskcafe
+        - pgcli postgres://taskcafe:taskcafe_test@localhost:8865/taskcafe

--- a/conf/taskcafe.example.toml
+++ b/conf/taskcafe.example.toml
@@ -1,5 +1,6 @@
 [server]
 hostname = '0.0.0.0:3333'
+remote_user_header = ""
 
 [email_notifications]
 enabled = true

--- a/docs/remote-auth.md
+++ b/docs/remote-auth.md
@@ -1,0 +1,9 @@
+# Remote authorize
+If you need to authenticate user with some proxy, you should use
+```toml
+[server]
+remote_user_header = "X-Remote-User"
+```
+With this option Taskcafe will take username from
+`X-Remote-User` HTTP header and will not check its password.
+You can use any header you want.

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -81,6 +81,7 @@ func Execute() {
 	viper.SetDefault("database.password", "taskcafe_test")
 	viper.SetDefault("database.port", "5432")
 	viper.SetDefault("security.token_expiration", "15m")
+	viper.SetDefault("server.remote_user_header", "")
 
 	viper.SetDefault("queue.broker", "amqp://guest:guest@localhost:5672/")
 	viper.SetDefault("queue.store", "memcache://localhost:11211")

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -65,8 +65,13 @@ type TaskcafeHandler struct {
 	SecurityConfig utils.SecurityConfig
 }
 
+type Config struct {
+	Email    utils.EmailConfig
+	Security utils.SecurityConfig
+}
+
 // NewRouter creates a new router for chi
-func NewRouter(dbConnection *sqlx.DB, emailConfig utils.EmailConfig, securityConfig utils.SecurityConfig) (chi.Router, error) {
+func NewRouter(dbConnection *sqlx.DB, cfg Config) (chi.Router, error) {
 	formatter := new(log.TextFormatter)
 	formatter.TimestampFormat = "02-01-2006 15:04:05"
 	formatter.FullTimestamp = true
@@ -93,7 +98,7 @@ func NewRouter(dbConnection *sqlx.DB, emailConfig utils.EmailConfig, securityCon
 	}))
 
 	repository := db.NewRepository(dbConnection)
-	taskcafeHandler := TaskcafeHandler{*repository, securityConfig}
+	taskcafeHandler := TaskcafeHandler{*repository, cfg.Security}
 
 	var imgServer = http.FileServer(http.Dir("./uploads/"))
 	r.Group(func(mux chi.Router) {
@@ -108,7 +113,7 @@ func NewRouter(dbConnection *sqlx.DB, emailConfig utils.EmailConfig, securityCon
 	r.Group(func(mux chi.Router) {
 		mux.Use(auth.Middleware)
 		mux.Post("/users/me/avatar", taskcafeHandler.ProfileImageUpload)
-		mux.Handle("/graphql", graph.NewHandler(*repository, emailConfig))
+		mux.Handle("/graphql", graph.NewHandler(*repository, cfg.Email))
 	})
 
 	frontend := FrontendHandler{staticPath: "build", indexPath: "index.html"}

--- a/internal/utils/security.go
+++ b/internal/utils/security.go
@@ -9,6 +9,11 @@ import (
 type SecurityConfig struct {
 	AccessTokenExpiration time.Duration
 	Secret                []byte
+	UserAuthHeader        string
+}
+
+func (c SecurityConfig) IsRemoteAuth() bool {
+	return c.UserAuthHeader != ""
 }
 
 func GetSecurityConfig(accessTokenExp string, secret []byte) (SecurityConfig, error) {


### PR DESCRIPTION
In some cases there are needs to Authorize user not in Taskcafe itself.
For this reason option server.remote_user_header was added.

```toml
[server]
remote_user_header = true
```

With turned on Taskcafe listens X-Remote-User http header and skip
password checking. But still check user existence and active flag.

* **Please check if the PR fulfills these requirements**
- [x] You have read the contribution guidelines [guidelines](https://github.com/JordanKnott/taskcafe/blob/master/CONTRIBUTING.md)
- [x] The commit message follows our [guidelines](https://github.com/JordanKnott/taskcafe/blob/master/CONTRIBUTING.md#git-commit-message-style)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This was in discussion https://github.com/JordanKnott/taskcafe/discussions/49

* **What is the current behavior?** (You can also link to an open issue here)
Check user and password at login handler. Add token in DB. Return cookie.

* **What is the new behavior (if this is a feature change)?**
Add an option server.remote_user_header (bool). Default is false.
If it's true – taskcafe will not check user password, but still find it in DB and check it's activeness.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
